### PR TITLE
Add tests for basic package functionality

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+^codecov\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@
 language: R
 sudo: false
 cache: packages
+os:
+  - linux
+  - osx
+
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,4 +26,5 @@ Remotes:
 RoxygenNote: 6.0.1
 Suggests:
     testthat,
-    lazyeval
+    lazyeval,
+    covr

--- a/R/runmodule.R
+++ b/R/runmodule.R
@@ -68,14 +68,14 @@ canonicalForm <- function(var)
 #' This function prints a diagnostic and returns an empty data frame.
 #'
 #' @keywords internal
-module.test_fun <- function(var, mode, allqueries, aggkeys, aggfn, strtyr, endyr,
-                    filters, ounit)
+module.test_fun <- function(mode, allqueries, aggkeys, aggfn, strtyr, endyr,
+                            filters, ounit)
 {
     if(mode == GETQ) {
-        character()
+        "Test Query"
     }
     else {
-        print(paste('Function for processing variable', var))
+        message('Test Module')
         data.frame()
     }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+comment:
+	behavior: new
+ignore: R/mcl.R

--- a/man/module.test_fun.Rd
+++ b/man/module.test_fun.Rd
@@ -4,8 +4,7 @@
 \alias{module.test_fun}
 \title{Test function for runModule}
 \usage{
-module.test_fun(var, mode, allqueries, aggkeys, aggfn, strtyr, endyr, filters,
-  ounit)
+module.test_fun(mode, allqueries, aggkeys, aggfn, strtyr, endyr, filters, ounit)
 }
 \description{
 This function prints a diagnostic and returns an empty data frame.

--- a/tests/testthat/test-data/test-query.xml
+++ b/tests/testthat/test-data/test-query.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<queries>
+	<aQuery>
+		<all-regions/>
+        	<demographicsQuery title="Test Query">
+			<axis1 name="region">region</axis1>
+			<axis2 name="Year">populationMiniCAM</axis2>
+			<xPath buildList="true" dataName="total-population" group="false" sumAll="false">demographics/populationMiniCAM/total-population/node()</xPath>
+			<comments/>
+        	</demographicsQuery>
+	</aQuery>
+</queries>

--- a/tests/testthat/test_runmodule.R
+++ b/tests/testthat/test_runmodule.R
@@ -1,0 +1,24 @@
+context('runModule and friends')
+
+test_that('Modules can be listed.', {
+    ml <- listModules()
+    expect_true(is.character(ml))
+    expect_true('test_fun' %in% ml)
+    expect_true('population' %in% ml)
+})
+
+test_that('Test module can be run through the generic interface.', {
+    rq <- runModule('test_fun', GETQ)
+    expect_identical(rq, 'Test Query')
+
+    expect_message({df <- runModule('test_fun', RUN)}, 'Test Module')
+    expect_equal(nrow(df), 0)
+})
+
+test_that('Test module gets found with non-canonical case.', {
+    rq <- runModule('TeSt_FuN', GETQ)
+    expect_identical(rq, 'Test Query')
+
+    expect_message({df <- runModule('TeSt_FUn', RUN)}, 'Test Module')
+    expect_equal(nrow(df), 0)
+})

--- a/tests/testthat/test_runqueries.R
+++ b/tests/testthat/test_runqueries.R
@@ -1,0 +1,34 @@
+context('Running queries')
+
+test_that('Default queries are read.', {
+    expect_true('parsed_queries' %in% names(private))
+    ## Check on a query
+    expect_true('GDP(MER)' %in% names(private$parsed_queries))
+    gdpquery <- private$parsed_queries[['GDP(MER)']]
+    expect_true(is.list(gdpquery))
+    expect_identical(names(gdpquery), c('regions', 'query', 'title'))
+    expect_identical(gdpquery$title, 'GDP(MER)')
+    expect_identical(gdpquery$regions, character(0))
+    expect_identical(gdpquery$query,
+                     "<gdpQueryBuilder title=\"GDP(MER)\">\n  <axis1 name=\"region\">region</axis1>\n  <axis2 name=\"Year\">gdp-mer</axis2>\n  <xPath buildList=\"true\" dataName=\"gdp-mer\" group=\"false\" sumAll=\"false\">GDP/gdp-mer/text()</xPath>\n  <comments/>\n</gdpQueryBuilder>")
+})
+
+test_that('We can parse a new query.', {
+    xmlfilename <- 'test-data/test-query.xml'
+    expect_false('Test Query' %in% names(private$parsed_queries))
+
+    parseQueries(xmlfilename)
+    expect_true('Test Query' %in% names(private$parsed_queries))
+})
+
+
+test_that('We can run a query.', {
+    qr <- runQueries('Population', dirname(rgcam:::SAMPLE.GCAMDB),
+                     basename(rgcam:::SAMPLE.GCAMDB))
+    expect_identical(names(qr), 'Population')
+    popdf <- qr[['Population']]
+    expect_true(is.data.frame(popdf))
+    expect_equal(nrow(popdf), 22)
+    expect_identical(names(popdf), c("Units", "scenario", "region",   "year",
+                                     "value", "rundate"))
+})


### PR DESCRIPTION
I've excluded the main control loop from the testing because I can't think of a way to do that without including a (prohibitively large) GCAM database in the repository.  

I've also added a coverage test to the CI, so we can see what kind of coverage we're getting with our tests.

Resolves #17 
