### PR TITLE
Disable mac builds in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@
 language: R
 sudo: false
 cache: packages
-os:
-  - linux
-  - osx
 
 after_success:
   - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
The mac builds are painfully backlogged on Travis right now.  We can
revert this commit once they have their mac build situation under
control again.